### PR TITLE
Make `…apply` include *all* current selections

### DIFF
--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -111,10 +111,9 @@ def find_end_parent_expression(lines, line_no):
 class ParinferApplyCommand(sublime_plugin.TextCommand):
     def run(self, edit, start_line = 0, end_line = 0, cursor_row = 0, cursor_col = 0, result_text = ''):
         # get the current selection
-        current_sel = self.view.sel()
-        end_cursor = current_sel[0].end()
-        end_row, end_col = self.view.rowcol(end_cursor)
-
+        current_selections = [(self.view.rowcol(start), self.view.rowcol(end)) 
+                              for start, end in self.view.sel()]
+        
         # update the buffer
         start_point = self.view.text_point(start_line, 0)
         end_point = self.view.text_point(end_line, 0)
@@ -122,10 +121,11 @@ class ParinferApplyCommand(sublime_plugin.TextCommand):
         self.view.replace(edit, region, result_text)
 
         # re-apply their selection
-        pt1 = self.view.text_point(cursor_row, cursor_col)
-        pt2 = self.view.text_point(end_row, end_col)
         self.view.sel().clear()
-        self.view.sel().add(sublime.Region(pt1, pt2))
+        for start, end in current_selections:
+            self.view.sel().add(
+                sublime.Region(self.view.text_point(*start),
+                               self.view.text_point(*end)))
 
 
 # NOTE: This command inspects the text around the cursor to determine if we need


### PR DESCRIPTION
Before this change, `parinfer_apply` would only restore the first selection which is incredibly frustrating when using multiple selections.

I use Parïnfer actively in my workflow and this change seems to work fine, including undo/redo.