### PR TITLE
wait for first modification before starting Parinfer

### DIFF
--- a/Parinfer.sublime-settings
+++ b/Parinfer.sublime-settings
@@ -6,5 +6,6 @@
     ".lfe",
     ".rkt",
     ".janet"
-  ]
+  ],
+  "run_paren_mode_when_file_opened": false
 }

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ because running Paren Mode on a file written using Parinfer will not result
 in any changes.
 
 However, this behavior was [sometimes confusing] for users new to Parinfer
-when they would open a file **not** written using Parinfer and see edits in
+when they would open a file not written using Parinfer and see edits in
 places they did not intend to make.
 
 [sometimes confusing]:https://github.com/oakmac/sublime-text-parinfer/issues/43

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have [Package Control] installed, you can easily install the
 
 You can symlink this repo to the Sublime Text Packages directory:
 
-```
+```sh
 cd ~
 git clone git@github.com:oakmac/sublime-text-parinfer.git
 ln -s ~/sublime-text-parinfer ~/Library/Application\ Support/Sublime\ Text/Packages/Parinfer
@@ -48,62 +48,43 @@ git clone https://github.com/oakmac/sublime-text-parinfer.git Parinfer
 
 ### File Extensions
 
-Once the package has been installed, it will automatically load in the
-background when you open Sublime Text and watch for file extensions found in a
-config file. The default file extensions are: `.clj` `.cljs` `.cljc` `.lfe`
-`.rkt` and `.janet`.
+Once installed, Parinfer will automatically activate when you open a file with
+a [known file extension].
 
-You can edit these file extensions by going to Preferences --> Package Settings -->
-Parinfer --> Settings
+You can change the list of watched file extensions by going to Preferences -->
+Package Settings --> Parinfer --> Settings.
 
-## Behavior Change for v1.0.0
-
-Before v1.0.0, when a file is opened, Paren Mode is run on the entire file,
-then the user is dropped into Indent Mode. For 99% of Parinfer users, this is
-not a problem because Paren Mode does not change anything in your file. But
-this can be jarring when you open a file that was written NOT with Parinfer,
-and Parinfer adjusts the file in places where you did not edit.
-
-So new with v1.0.0, Parinfer will enter "Waiting" mode when a file is opened.
-And it is waiting for the **first modification to the buffer**, and then then
-Indent Mode will be turned on.
-
-Also the "parent expression hack" is now a bit less aggressive about
-"searching up" and "searching down" from the cursor location.
-
-For most regular users of Parinfer, these changes should basically not be
-noticeable. But hopefully results in a better experience for newer users.
-
-If you prefer the old behavior of "run full Paren Mode on the whole file
-when it is opened", there is a new config flag `run_paren_mode_when_file_opened`
-to set that behavior.
+[known file extension]:https://github.com/oakmac/sublime-text-parinfer/blob/master/Parinfer.sublime-settings#L2-L9
 
 ### Opening a File
 
-When a file with a recognized extension is first opened, Parinfer runs [Paren
-Mode] on the entire file and one of three things will happen (in order of
-likelihood):
+When a file with a recognized extension is opened, Parinfer will enter
+`Parinfer: Waiting` mode and wait for the **first edit to the buffer**. When
+the first edit occurs, Parinfer will enter `Parinfer: Indent` mode and begin
+controlling closing parenthesis based on indentation.
 
-* **The file was unchanged.** You will be automatically dropped into Indent
-  Mode. This is the most likely scenario once you start using Parinfer
-  regularly.
-* **Paren Mode changed the file.** The buffer will receive the changes and you
-  will be dropped into Indent Mode. This is most likely to happen when you first
-  start using Parinfer on an existing file.
-* **Paren Mode failed.** This is almost certainly caused by having unbalanced
-  parens in your file (ie: it will not compile). The text will not be changed
-  and you will be dropped into Paren Mode in order to fix the problem.
+### Behavior Change for v1.0.0
 
-Running Paren Mode is a necessary first step before Indent Mode can be safely
-turned on. See [Fixing existing files] for more information.
+Before v1.0.0, when a file was opened Parinfer would run Paren Mode on the
+entire file first before entering Indent Mode (see [Fixing existing files]
+for more details). This was not a problem for regular users of Parinfer
+because running Paren Mode on a file written using Parinfer will not result
+in any changes.
 
-Please be aware that - depending on the indentation and formatting in your Lisp
-files - this initial processing may result in a large diff the first time it
-happens. Once you start using Indent Mode regularly, this initial processing is
-unlikely to result in a large diff (or any diff at all). You may even discover
-that applying Paren Mode to a file can result in [catching very hard-to-find
-bugs] in your existing code! As usual, developers are responsible for reviewing
-their diffs before a code commit :)
+However, this behavior was [sometimes confusing] for users new to Parinfer
+when they would open a file **not** written using Parinfer and see edits in
+places they did not intend to make.
+
+[sometimes confusing]:https://github.com/oakmac/sublime-text-parinfer/issues/43
+
+Starting with v1.0.0, Parinfer will first enter "Waiting" mode and only begin
+controlling closing parens after the first modification to the buffer. If you
+desire the pre-v1.0.0 behavior, set the config setting
+`run_paren_mode_when_file_opened` to `true`.
+
+Additionally, there is a new `Parinfer: Run Paren Mode on Current Buffer`
+command that can be executed at anytime and will run Paren Mode over the
+entire active buffer.
 
 ### Hotkeys and Status Bar
 
@@ -115,22 +96,16 @@ their diffs before a code commit :)
 The status bar will indicate which mode you are in or show nothing if Parinfer
 is turned off.
 
-### Future Features
+## The "parent expression" hack
 
-More options and configuration settings are planned for future releases. Browse
-the [issues] for an idea of future features. Create a new issue if you can think
-of a useful feature :)
-
-## Known Limitations
-
-This extension uses a hack for performance reasons that may act oddly in certain
-circumstances. It assumes that an open paren followed by an alpha character -
-ie: regex `^\([a-zA-Z]` - at the start of a line is the beginning of a new
-"parent expression" and tells the Parinfer algorithm to start analyzing from
-there until the next line that matches the same regex. Most of the time this is
-probably a correct assumption, but might break inside multi-line strings or
-other non-standard circumstances. This is tracked at [Issue #23]; please add to
-that if you experience problems.
+This extension uses a hack for performance reasons that may result in odd
+behavior in rare cases. It assumes that an open paren followed by an alpha
+character - ie: regex `^\([a-zA-Z]` - at the start of a line is the beginning
+of a new "parent expression" and tells the Parinfer algorithm to start
+analyzing from there until the next line that matches the same regex. Most of
+the time this is probably a correct assumption, but might break inside
+multi-line strings or other non-standard circumstances. This is tracked at
+[Issue #23]; please add to that if you experience problems.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can symlink this repo to the Sublime Text Packages directory:
 ```
 cd ~
 git clone git@github.com:oakmac/sublime-text-parinfer.git
-ln -s ~/sublime-text-parinfer ~/Library/Application\ Support/Sublime\ Text/Packages/
+ln -s ~/sublime-text-parinfer ~/Library/Application\ Support/Sublime\ Text/Packages/Parinfer
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -51,10 +51,32 @@ git clone https://github.com/oakmac/sublime-text-parinfer.git Parinfer
 Once the package has been installed, it will automatically load in the
 background when you open Sublime Text and watch for file extensions found in a
 config file. The default file extensions are: `.clj` `.cljs` `.cljc` `.lfe`
-`.rkt`
+`.rkt` and `.janet`.
 
 You can edit these file extensions by going to Preferences --> Package Settings -->
-Parinfer --> Settings - Default
+Parinfer --> Settings
+
+## Behavior Change for v1.0.0
+
+Before v1.0.0, when a file is opened, Paren Mode is run on the entire file,
+then the user is dropped into Indent Mode. For 99% of Parinfer users, this is
+not a problem because Paren Mode does not change anything in your file. But
+this can be jarring when you open a file that was written NOT with Parinfer,
+and Parinfer adjusts the file in places where you did not edit.
+
+So new with v1.0.0, Parinfer will enter "Waiting" mode when a file is opened.
+And it is waiting for the **first modification to the buffer**, and then then
+Indent Mode will be turned on.
+
+Also the "parent expression hack" is now a bit less aggressive about
+"searching up" and "searching down" from the cursor location.
+
+For most regular users of Parinfer, these changes should basically not be
+noticeable. But hopefully results in a better experience for newer users.
+
+If you prefer the old behavior of "run full Paren Mode on the whole file
+when it is opened", there is a new config flag `run_paren_mode_when_file_opened`
+to set that behavior.
 
 ### Opening a File
 

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -311,9 +311,7 @@ class ParinferRunParenCurrentBuffer(sublime_plugin.TextCommand):
         if lines[-1] != "":
             lines.append("")
 
-        # we do not need to pass any option to paren_mode() here
-        ## FIXME: do we need to pass comment char? I think the answer is "yes"
-        result = paren_mode(all_text, {})
+        result = paren_mode(all_text, { 'comment': get_comment_char(self.view) })
 
         if result['success']:
             cmd_options = {
@@ -322,6 +320,9 @@ class ParinferRunParenCurrentBuffer(sublime_plugin.TextCommand):
                 'result_text': result['text'],
             }
             sublime.set_timeout(lambda: current_view.run_command('parinfer_apply', cmd_options), 1)
+        else:
+            ## TODO: it would be nice to show them the line number / character where this failed
+            sublime.status_message('Paren mode failed. Do you have unbalanced parens?')
 
 
 class ParinferUndoListener(sublime_plugin.EventListener):

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -210,6 +210,7 @@ class Parinfer(sublime_plugin.EventListener):
 
         # stateful debounce counter
         self.pending = 0
+
         self.buffers_with_modifications = {}
 
     # Should we automatically start Parinfer on this file?
@@ -255,8 +256,6 @@ class Parinfer(sublime_plugin.EventListener):
         sublime.set_timeout(
             functools.partial(self.handle_timeout, view), DEBOUNCE_INTERVAL_MS)
 
-    ## FIXME: need to clear the buffers_with_modifications cache when we unload a view / buffer
-
     # fires everytime a selection changes (ie: the cursor is moved)
     def on_selection_modified(self, view):
         # do nothing if Parinfer is not enabled
@@ -280,6 +279,14 @@ class Parinfer(sublime_plugin.EventListener):
         else:
             debug_log("File has been loaded, but do not start Parinfer")
 
+    # called when a view is closed
+    def on_close(self, view):
+        buffer_id = view.buffer_id()
+        clones = view.clones()
+
+        # clear the buffers_with_modifications cache if this is the last view into that Buffer
+        if len(clones) == 0 and buffer_id in self.buffers_with_modifications:
+            del self.buffers_with_modifications[buffer_id]
 
 class ParinferToggleOnCommand(sublime_plugin.TextCommand):
     def run(self, _edit):

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -88,31 +88,21 @@ def is_parent_expression(txt):
 
 
 def find_start_parent_expression(lines, line_no):
-    line_no = line_no - 4
-    if line_no < 0:
-        return 0
-
     idx = line_no - 1
     while idx > 0:
         if is_parent_expression(lines[idx]):
             return idx
         idx = idx - 1
-
     return 0
 
 
 def find_end_parent_expression(lines, line_no):
     max_idx = len(lines) - 1
-    line_no = line_no + 4
-    if line_no > max_idx:
-        return max_idx
-
     idx = line_no + 1
     while idx < max_idx:
         if is_parent_expression(lines[idx]):
             return idx
         idx = idx + 1
-
     return max_idx
 
 
@@ -292,7 +282,7 @@ class Parinfer(sublime_plugin.EventListener):
     def on_selection_modified(self, view):
         # do nothing if Parinfer is not enabled
         status = view.get_status(STATUS_KEY)
-        if status not in (INDENT_STATUS, PAREN_STATUS, PENDING_STATUS):
+        if status not in ALL_STATUSES:
             return
 
         # Run Parinfer if this is a buffer that has been modified

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -34,9 +34,10 @@ DEBUG_LOGGING = True
 # constants
 DEBOUNCE_INTERVAL_MS = 50
 STATUS_KEY = 'parinfer'
-PENDING_STATUS = 'Parinfer: Waiting for first modification'
+PENDING_STATUS = 'Parinfer: Waiting'
 INDENT_STATUS = 'Parinfer: Indent'
 PAREN_STATUS = 'Parinfer: Paren'
+ALL_STATUSES = [PENDING_STATUS, INDENT_STATUS, PAREN_STATUS]
 PARENT_EXPRESSION_RE = re.compile(r"^\([a-zA-Z]")
 SYNTAX_LANGUAGE_RE = r"([\w\d\s]*)(\.sublime-syntax)"
 
@@ -157,7 +158,7 @@ class ParinferInspectCommand(sublime_plugin.TextCommand):
         current_status = current_view.get_status(STATUS_KEY)
 
         # exit if Parinfer is not enabled on this view
-        if current_status not in (INDENT_STATUS, PAREN_STATUS, PENDING_STATUS):
+        if current_status not in ALL_STATUSES:
             return
 
         whole_region = sublime.Region(0, current_view.size())

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -29,7 +29,7 @@ except NameError:
     basestring = str
 
 # dev flag
-DEBUG_LOGGING = True
+DEBUG_LOGGING = False
 
 # constants
 DEBOUNCE_INTERVAL_MS = 50
@@ -202,27 +202,6 @@ class ParinferInspectCommand(sublime_plugin.TextCommand):
                     'result_text': result['text'],
                 }
                 sublime.set_timeout(lambda: current_view.run_command('parinfer_apply', cmd_options), 1)
-
-
-# class ParinferParenOnOpen(sublime_plugin.TextCommand):
-#     def run(self, edit):
-#         # run Paren Mode on the whole file
-#         whole_region = sublime.Region(0, self.view.size())
-#         all_text = self.view.substr(whole_region)
-#         result = paren_mode(all_text, None)
-
-#         # TODO:
-#         # - what to do when paren mode fails on a new file?
-#         #   show them a message?
-#         # - warn them before applying Paren Mode changes?
-
-#         if result['success']:
-#             # update the buffer if we need to
-#             if all_text != result['text']:
-#                 self.view.replace(edit, whole_region, result['text'])
-
-#             # drop them into Indent Mode
-#             self.view.set_status(STATUS_KEY, INDENT_STATUS)
 
 
 class Parinfer(sublime_plugin.EventListener):

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -77,13 +77,8 @@ def get_comment_char(view):
 
 def get_setting(view, key):
     settings = view.settings().get('Parinfer')
-    print("settings1", settings)
     if settings is None:
         settings = sublime.load_settings('Parinfer.sublime-settings')
-        print("settings2", settings)
-
-    print("settings as a dict:", settings.to_dict())
-
     return settings.get(key)
 
 
@@ -258,14 +253,7 @@ class Parinfer(sublime_plugin.EventListener):
         # NOTE: I was occasionally seeing a runtime error here about file_extensions
         # not being an Iterable, so wrapped in try/catch to be defensive.
         # -- C. Oakman, 22 Feb 2023
-
-        ## FIXME: not working
-        #file_extensions = get_setting(view, 'file_extensions')
-
-
-        file_extensions = [".clj", ".cljs"]
-        print("file extensions:", file_extensions)
-
+        file_extensions = get_setting(view, 'file_extensions')
         try:
             for extension in file_extensions:
                 if filename.endswith(extension):

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -28,6 +28,9 @@ try:
 except NameError:
     basestring = str
 
+# dev flag
+DEBUG_LOGGING = True
+
 # constants
 DEBOUNCE_INTERVAL_MS = 50
 STATUS_KEY = 'parinfer'
@@ -36,6 +39,12 @@ INDENT_STATUS = 'Parinfer: Indent'
 PAREN_STATUS = 'Parinfer: Paren'
 PARENT_EXPRESSION_RE = re.compile(r"^\([a-zA-Z]")
 SYNTAX_LANGUAGE_RE = r"([\w\d\s]*)(\.sublime-syntax)"
+
+
+def debug_log(x):
+    if DEBUG_LOGGING == True:
+        print("DEBUG:", x)
+
 
 def get_syntax_language(view):
     regex_res = re.search(SYNTAX_LANGUAGE_RE, view.settings().get("syntax"))
@@ -232,11 +241,10 @@ class ParinferInspectCommand(sublime_plugin.TextCommand):
 
 class Parinfer(sublime_plugin.EventListener):
     def __init__(self):
-        print("INIT INIT INIT")
+        debug_log('Parinfer plugin init')
+
         # stateful debounce counter
         self.pending = 0
-
-
         self.buffers_with_modifications = {}
 
     # Should we automatically start Parinfer on this file?
@@ -301,18 +309,18 @@ class Parinfer(sublime_plugin.EventListener):
         # Run Parinfer if this is a buffer that has been modified
         buffer_id = view.buffer_id()
         if buffer_id in self.buffers_with_modifications and self.buffers_with_modifications[buffer_id] == True:
-            print("selection change, buffer has been modified, run parinfer")
+            debug_log("selection change, buffer has been modified, run Parinfer")
             self.on_modified(view)
         else:
-            print("selection change, buffer has NOT been modified, do nothing")
+            debug_log("selection change, buffer has NOT been modified, do nothing")
 
     # fires when a file is finished loading
     def on_load(self, view):
         if self.should_start(view):
-            print("File has been loaded, we automatically start Parinfer")
+            debug_log("File has been loaded, automatically start Parinfer")
             view.set_status(STATUS_KEY, PENDING_STATUS)
         else:
-            print("File has been loaded, but do not start Parinfer")
+            debug_log("File has been loaded, but do not start Parinfer")
 
 
 class ParinferToggleOnCommand(sublime_plugin.TextCommand):

--- a/sublime-parinfer.py
+++ b/sublime-parinfer.py
@@ -250,7 +250,7 @@ class Parinfer(sublime_plugin.EventListener):
         if view.get_status(STATUS_KEY) == PENDING_STATUS:
             view.set_status(STATUS_KEY, INDENT_STATUS)
 
-        # Run Parinfer
+        # run Parinfer
         self.pending = self.pending + 1
         sublime.set_timeout(
             functools.partial(self.handle_timeout, view), DEBOUNCE_INTERVAL_MS)
@@ -264,7 +264,7 @@ class Parinfer(sublime_plugin.EventListener):
         if status not in ALL_STATUSES:
             return
 
-        # Run Parinfer if this is a buffer that has been modified
+        # run Parinfer if this is a buffer that has been modified
         buffer_id = view.buffer_id()
         if buffer_id in self.buffers_with_modifications and self.buffers_with_modifications[buffer_id] == True:
             debug_log("selection change, buffer has been modified, run Parinfer")


### PR DESCRIPTION
[Issue #43](https://github.com/oakmac/sublime-text-parinfer/issues/43)

* fix symlink instructions in README
* do not run Paren Mode on the full file when it is first opened
* drop the user into "Waiting" mode when a file is opened where Parinfer should be enabled
* once we see the first modification, then turn on Indent Mode like normal
* reduce the up / down range that Parinfer looks for parent expressions (with the goal of minimizing changes in longer files)
* adds config flag `run_paren_mode_when_file_opened` with default `false`

### TODO:

- [x] update README with new "waiting" behavior
- [x] add config flag for always running Paren Mode on files when they are opened (ie: bypassing "Waiting" mode)
- [x] pass comment char to Paren Mode
- [x] clear modified buffer cache on unload
